### PR TITLE
Ensure timer starts on first key press

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,7 +16,7 @@ export default function App() {
   const [allWordCount, setAllWordCount] = useState(0);
   const [trackKeyCount, setTrackKeyCount] = useState([0]);
   const [wordErrorIndex, setWordErrorIndex] = useState([]);
-  const [showWordCount, setShowWordCount] = useState(false);
+  const [endOfTest, setEndOfTest] = useState(false);
 
   const nextLetterIndex = typedKey.length;
   const currentLetter = sentence[nextLetterIndex];
@@ -27,12 +27,15 @@ export default function App() {
   const noErrorInWord = !wordErrorIndex.includes(allWordCount);
 
   useEffect(() => {
-    document.addEventListener("keydown", handleKeyPress);
+    // Prevent further typing when the test ends.
+    if (!endOfTest) {
+      document.addEventListener("keydown", handleKeyPress);
+    }
 
     return () => {
       document.removeEventListener("keydown", handleKeyPress);
     };
-  }, [trackKeyIndex]);
+  }, [trackKeyIndex, endOfTest]);
 
   const handleKeyPress = (event) => {
     // Handle Shift and Tab. Display message if caps lock.
@@ -167,8 +170,8 @@ export default function App() {
     setTrackKeyIndex((prevTrackKeyIndex) => prevTrackKeyIndex + 1);
   };
 
-  const handleShowWordCount = () => {
-    setShowWordCount(true);
+  const handleEndOfTest = () => {
+    setEndOfTest(true);
   };
 
   return (
@@ -177,12 +180,9 @@ export default function App() {
         <img className="logo-icon" src="/keyboard.svg" alt="Keyboard" />
         <div className="logo-text">Key Sprint</div>
       </div>
-      {!showWordCount && (
+      {!endOfTest ? (
         <div className="text-container">
-          <Timer
-            handleShowWordCount={handleShowWordCount}
-            trackKeyIndex={trackKeyIndex}
-          />
+          <Timer handleEndOfTest={handleEndOfTest} />
           <Sentence
             sentence={sentence}
             errorIndexes={errorIndexes}
@@ -190,8 +190,9 @@ export default function App() {
             typedKey={typedKey}
           />
         </div>
+      ) : (
+        <WordCount count={correctWordCount} />
       )}
-      <WordCount showWordCount={showWordCount} count={correctWordCount} />
     </div>
   );
 }

--- a/src/Timer.jsx
+++ b/src/Timer.jsx
@@ -1,29 +1,37 @@
 import React, { useEffect, useState } from "react";
 
-export default function Timer({ handleShowWordCount, trackKeyIndex }) {
+export default function Timer({ handleEndOfTest }) {
   const [countDown, setCountdown] = useState(30);
-  const [showTimer, setShowTimer] = useState(false);
+  const [startTimer, setStartTimer] = useState(false);
 
   useEffect(() => {
-    document.addEventListener("keydown", handleFirstKeyPress);
+    let timer;
 
-    const timer = setTimeout(() => {
-      setCountdown((prevCountDown) => Math.max(0, prevCountDown - 1));
-    }, 1000);
+    if (startTimer) {
+      timer = setTimeout(() => {
+        setCountdown((prevCountDown) => Math.max(0, prevCountDown - 1));
+      }, 1000);
+    } else {
+      document.addEventListener("keydown", handleFirstKeyPress);
+    }
 
     if (countDown === 0) {
-      handleShowWordCount();
+      handleEndOfTest();
     }
 
     return () => {
-      document.addEventListener("keydown", handleFirstKeyPress);
       clearTimeout(timer);
+      // As the event listener is added conditionally this is not neccessary,
+      // however still good practice to remove the listener.
+      if (!startTimer) {
+        document.removeEventListener("keydown", handleFirstKeyPress);
+      }
     };
-  }, [countDown]);
+  }, [countDown, startTimer]);
 
   const handleFirstKeyPress = () => {
-    setShowTimer(true);
+    setStartTimer(true);
   };
 
-  return showTimer && <div className="timer">{countDown}</div>;
+  return <div className="timer">{countDown}</div>;
 }

--- a/src/WordCount.jsx
+++ b/src/WordCount.jsx
@@ -1,9 +1,7 @@
-export default function WordCount({ count, showWordCount }) {
+export default function WordCount({ count }) {
   return (
-    showWordCount && (
-      <div className="popup">
-        <div className="word-counter">Your WPM: {count}</div>
-      </div>
-    )
+    <div className="popup">
+      <div className="word-counter">Your WPM: {count}</div>
+    </div>
   );
 }


### PR DESCRIPTION
The time starts only when the first key is pressed.

Also ensure the handleKeyPress event listener is not added when the word count displays.